### PR TITLE
Fix a bug to traverse only one thread even when multi-threads had been recorded.

### DIFF
--- a/org.ntlab.traceAnalysisPlatform/src/org/ntlab/traceAnalysisPlatform/tracer/trace/Trace.java
+++ b/org.ntlab.traceAnalysisPlatform/src/org/ntlab/traceAnalysisPlatform/tracer/trace/Trace.java
@@ -942,6 +942,9 @@ public class Trace {
 					traceCurThread2 = traceCurThread;
 					traceCurTime = methodEntry;
 					traceCurThread = threadId;
+				} else if (traceCurTime2 == -1 || traceCurTime2 > methodEntry) {
+					traceCurTime2 = methodEntry;
+					traceCurThread2 = threadId;
 				}
 			} else {
 				threadCurPoints.put(threadId, null);				
@@ -1040,6 +1043,9 @@ public class Trace {
 					traceLastThread2 = traceLastThread;
 					traceLastTime = methodEntry;
 					traceLastThread = threadId;
+				} else if (traceLastTime2 < methodEntry) {
+					traceLastTime2 = methodEntry;
+					traceLastThread2 = threadId;
 				}
 			} else {
 				threadLastPoints.put(threadId, null);				

--- a/org.ntlab.traceAnalysisPlatform/src/org/ntlab/traceAnalysisPlatform/tracer/trace/TraceJSON.java
+++ b/org.ntlab.traceAnalysisPlatform/src/org/ntlab/traceAnalysisPlatform/tracer/trace/TraceJSON.java
@@ -707,6 +707,9 @@ public class TraceJSON extends Trace {
 					traceLastThread2 = traceLastThread;
 					traceLastTime = threadLastTime;
 					traceLastThread = threadId;
+				} else if (traceLastTime2 < threadLastTime) {
+					traceLastTime2 = threadLastTime;
+					traceLastThread2 = threadId;
 				}
 			} else {
 				threadLastPoints.put(threadId, null);	
@@ -835,6 +838,9 @@ public class TraceJSON extends Trace {
 						traceLastThread2 = traceLastThread;
 						traceLastTime = threadLastTime;
 						traceLastThread = threadId;
+					} else if (traceLastTime2 < threadLastTime) {
+						traceLastTime2 = threadLastTime;
+						traceLastThread2 = threadId;
 					}
 				}					
 			} else {


### PR DESCRIPTION
I have fixed the bug.